### PR TITLE
feat: add zoom/scale support to Grid component and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A flexible grid/canvas layout component for React, built with TypeScript. It uti
   - Provides coordinates, validity status, and selected item IDs via callback.
 - **Custom Handles:** Supports custom components for resize handles and specific drag handle elements.
 - **Dynamic Styling:** Allows applying custom classes to the canvas, drop zone shadow, and individual items.
+- **Zoom / Scale Support:** Optional `scale` prop lets you zoom the entire grid while preserving correct drag, resize and selection behaviors.
 
 ## Installation
 
@@ -67,6 +68,7 @@ function MyComponent() {
     enableSelectionTool: true,
     gridUnitSize: 10,
     resizeUnitSize: 10,
+    scale: 1,
     onDragStart: (id, pos) => console.log('drag started', id, pos),
     onDragEnd: (id, pos) => console.log('drag ended', id, pos),
     onResizeStart: (id, rect) => console.log('resize started', id, rect),
@@ -126,6 +128,7 @@ export default MyComponent
 | `onDragEnd`                | `(itemId: string, position: { x: number; y: number }) => void`                                                                                                     | `undefined`                   | Callback when an item drag ends; provides ID and final position (snapped).                                                                     |
 | `onResizeStart`            | `(itemId: string, rect: { x: number; y: number; width: number; height: number }) => void`                                                                          | `undefined`                   | Callback when an item resize begins; provides ID and starting rectangle (snapped).                                                             |
 | `onResizeEnd`              | `(itemId: string, rect: { x: number; y: number; width: number; height: number }) => void`                                                                          | `undefined`                   | Callback when an item resize ends; provides ID and final rectangle (snapped).                                                                  |
+| `scale`                    | `number`                                                                                                                                                           | `1`                           | Optional CSS scale factor for the grid container; zooms the canvas while maintaining accurate interactions                                     |
 
 ## Callbacks
 

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -3,7 +3,7 @@ import { Button } from './components/ui/button'
 import Grid, { GridItem, SelectionRectangle, MousePosition } from '../../../src/index'
 import { Switch } from './components/ui/switch'
 import { Popover, PopoverTrigger, PopoverContent } from './components/ui/popover'
-import { SquareDashedMousePointer } from 'lucide-react'
+import { SquareDashedMousePointer, ZoomOut, ZoomIn } from 'lucide-react'
 import ItemCard from './components/ItemCard'
 import './App.css'
 
@@ -33,7 +33,8 @@ function App() {
   const [enableSelectionTool, setEnableSelectionTool] = useState(false)
   const [useCustomDragHandle, setUseCustomDragHandle] = useState(false)
   const [selectOnlyEmptySpace, setSelectOnlyEmptySpace] = useState(true)
-  const [showGrid, setShowGrid] = useState(false) // State for grid lines
+  const [showGrid, setShowGrid] = useState(false)
+  const [scale, setScale] = useState<number>(1)
 
   // Popover/Selection State
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
@@ -200,6 +201,17 @@ function App() {
           <label>Grid Lines</label>
           <Switch checked={showGrid} onCheckedChange={setShowGrid} />
         </div>
+        <div className="flex justify-between items-center w-full">
+          <label>Scale</label>
+          <div className="flex space-x-2">
+            <Button variant="outline" onClick={() => setScale(s => Math.max(0.1, s - 0.1))}>
+              <ZoomOut className="h-5 w-5" />
+            </Button>
+            <Button variant="outline" onClick={() => setScale(s => +(s + 0.1).toFixed(1))}>
+              <ZoomIn className="h-5 w-5" />
+            </Button>
+          </div>
+        </div>
       </div>
       <Popover open={isPopoverOpen} onOpenChange={handlePopoverOpenChange}>
         <PopoverTrigger style={popoverPositionStyle} />
@@ -227,6 +239,7 @@ function App() {
 
       <div className="mt-8 flex justify-center">
         <Grid
+          scale={scale}
           layout={layout}
           onLayoutChange={handleLayoutChange}
           width={800}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-gridy-canvas",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A draggable and resizable grid/canvas layout component for React with snapping, collision handling, and selection.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -12,6 +12,7 @@ const DRAG_THRESHOLD = 5
 const Grid: React.FC<GridProps> = ({
   width,
   height,
+  scale = 1,
   gridUnitSize = 10,
   resizeUnitSize = 10,
   gap = 0,
@@ -43,13 +44,10 @@ const Grid: React.FC<GridProps> = ({
   // derive numeric grid units for x/y
   const [gridUnitX, gridUnitY] = Array.isArray(gridUnitSize) ? gridUnitSize : [gridUnitSize, gridUnitSize]
   const [resizeUnitW, resizeUnitH] = Array.isArray(resizeUnitSize) ? resizeUnitSize : [resizeUnitSize, resizeUnitSize]
-  // effective snap and resize units
   const effSnapX = gridUnitX
   const effSnapY = gridUnitY
   const effResizeW = resizeUnitW
   const effResizeH = resizeUnitH
-  // compute actual pixel gap: number of gap units * gridUnitX
-  // pixelGap now handled inside simulateQueueShift
   const computedMinSelectionArea = minSelectionArea ?? gridUnitX * gridUnitY
 
   // Internal interaction state
@@ -79,6 +77,7 @@ const Grid: React.FC<GridProps> = ({
     layout,
     width,
     height,
+    scale,
     snapGridUnit: gridUnitSize,
     enableSelectionTool,
     selectOnlyEmptySpace,
@@ -364,7 +363,6 @@ const Grid: React.FC<GridProps> = ({
       const snappedWidth = Math.max(effResizeW, snapToGrid(initialSize.width + delta.width, effResizeW))
       const snappedHeight = Math.max(effResizeH, snapToGrid(initialSize.height + delta.height, effResizeH))
       const finalSize = { width: snappedWidth, height: snappedHeight }
-
       onResizeEndProp?.(wasResizingId, { x: snappedX, y: snappedY, width: snappedWidth, height: snappedHeight })
       const { previewLayout: finalSimLayout, canDrop } = simulateQueueShift(
         layout,
@@ -417,8 +415,6 @@ const Grid: React.FC<GridProps> = ({
       gridUnitSize,
     ],
   )
-
-  // --- Grid Lines ---
   // Rendering
   const childrenMap = new Map<string, ReactNode>()
   Children.forEach(children, (child) => {
@@ -447,6 +443,8 @@ const Grid: React.FC<GridProps> = ({
       style={{
         width: `${width}px`,
         height: `${height}px`,
+        transform: `scale(${scale})`,
+        transformOrigin: '0 0',
         cursor: enableSelectionTool && !isLocked ? 'crosshair' : undefined,
       }}
       onMouseDown={handleSelectionMouseDown}
@@ -520,6 +518,7 @@ const Grid: React.FC<GridProps> = ({
 
         return (
           <Rnd
+            scale={scale}
             dragStartThreshold={5}
             key={item.id}
             size={currentSize}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface GridProps {
   width: number
   /** Height of the canvas */
   height: number
+  /** Scale (zoom) factor for the grid container */
+  scale?: number
   /** Grid unit size for snapping position; can be single number or [x, y] */
   gridUnitSize?: number | [number, number]
   /** Grid unit size for snapping resize dimensions; single number or [width, height] */

--- a/src/utils/selection-utils.ts
+++ b/src/utils/selection-utils.ts
@@ -12,6 +12,8 @@ interface UseSelectionHandlerProps {
   layout: GridItem[]
   width: number
   height: number
+  /** Scale factor of the canvas */
+  scale?: number
   snapGridUnit: number | [number, number]
   enableSelectionTool: boolean
   selectOnlyEmptySpace: boolean
@@ -44,6 +46,7 @@ export const useSelectionHandler = ({
   layout,
   width,
   height,
+  scale = 1,
   snapGridUnit,
   enableSelectionTool,
   selectOnlyEmptySpace,
@@ -111,8 +114,8 @@ export const useSelectionHandler = ({
       if (!isSelecting || !selectionStart || !canvasRef.current) return
 
       const rect = canvasRef.current.getBoundingClientRect()
-      const relX = clientX - rect.left
-      const relY = clientY - rect.top
+      const relX = (clientX - rect.left) / scale
+      const relY = (clientY - rect.top) / scale
       const currentX = Math.max(0, Math.min(relX, width))
       const currentY = Math.max(0, Math.min(relY, height))
       const startX = selectionStart.x
@@ -167,6 +170,7 @@ export const useSelectionHandler = ({
       minSelectionArea,
       selectOnlyEmptySpace,
       layout,
+      scale,
     ],
   )
 
@@ -181,8 +185,8 @@ export const useSelectionHandler = ({
       }
 
       const rect = canvasRef.current.getBoundingClientRect()
-      const relX = clientX - rect.left
-      const relY = clientY - rect.top
+      const relX = (clientX - rect.left) / scale
+      const relY = (clientY - rect.top) / scale
       const finalCurrentX = Math.max(0, Math.min(relX, width))
       const finalCurrentY = Math.max(0, Math.min(relY, height))
       const startX = selectionStart.x
@@ -273,6 +277,7 @@ export const useSelectionHandler = ({
       layout,
       onSelectionEnd,
       clearSelectionState,
+      scale,
     ],
   )
 
@@ -318,8 +323,8 @@ export const useSelectionHandler = ({
 
       if (!canvasRef.current) return
       const rect = canvasRef.current.getBoundingClientRect()
-      const startX = e.clientX - rect.left
-      const startY = e.clientY - rect.top
+      const startX = (e.clientX - rect.left) / scale
+      const startY = (e.clientY - rect.top) / scale
 
       if (startX < 0 || startX > width || startY < 0 || startY > height) {
         return
@@ -350,6 +355,7 @@ export const useSelectionHandler = ({
       canvasRef,
       draggingItemIdRef,
       resizingItemIdRef,
+      scale,
     ],
   )
 
@@ -360,8 +366,8 @@ export const useSelectionHandler = ({
       if (!listenersAttachedRef.current) {
         if (canvasRef.current) {
           const rect = canvasRef.current.getBoundingClientRect()
-          const relCurrentX = e.clientX - rect.left
-          const relCurrentY = e.clientY - rect.top
+          const relCurrentX = (e.clientX - rect.left) / scale
+          const relCurrentY = (e.clientY - rect.top) / scale
           const dx = Math.abs(relCurrentX - selectionStart.x)
           const dy = Math.abs(relCurrentY - selectionStart.y)
           const distance = Math.sqrt(dx * dx + dy * dy)
@@ -378,7 +384,7 @@ export const useSelectionHandler = ({
 
       processSelectionMove(e.clientX, e.clientY)
     },
-    [isSelecting, selectionStart, canvasRef, handleGlobalMouseMove, handleGlobalMouseUp, processSelectionMove],
+    [isSelecting, selectionStart, canvasRef, handleGlobalMouseMove, handleGlobalMouseUp, processSelectionMove, scale],
   )
 
   const handleMouseUp = useCallback(


### PR DESCRIPTION
## Description

Add zoom (scale) support to the Grid component by exposing an optional scale prop and wiring it through to CSS transforms, react‑rnd and the selection handler. This allows users to zoom the canvas without breaking drag, resize or selection logic.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Type of change

 n/a