### PR TITLE
feat: add transformOrigin prop to Grid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-gridy-canvas",
-  "version": "0.1.2",
+  "version": "0.1.21",
   "description": "A draggable and resizable grid/canvas layout component for React with snapping, collision handling, and selection.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -13,6 +13,7 @@ const Grid: React.FC<GridProps> = ({
   width,
   height,
   scale = 1,
+  transformOrigin = '0px 0px',
   gridUnitSize = 10,
   resizeUnitSize = 10,
   gap = 0,
@@ -444,7 +445,7 @@ const Grid: React.FC<GridProps> = ({
         width: `${width}px`,
         height: `${height}px`,
         transform: `scale(${scale})`,
-        transformOrigin: '0 0',
+        transformOrigin,
         cursor: enableSelectionTool && !isLocked ? 'crosshair' : undefined,
       }}
       onMouseDown={handleSelectionMouseDown}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface GridProps {
   width: number
   /** Height of the canvas */
   height: number
+  /** Optional CSS transform-origin for the grid container; no origin applied by default */
+  transformOrigin?: string
   /** Scale (zoom) factor for the grid container */
   scale?: number
   /** Grid unit size for snapping position; can be single number or [x, y] */


### PR DESCRIPTION
## Description

Introduce optional transformOrigin prop on the Grid component (defaults to 0px 0px) to control the CSS transform-origin when using the existing scale prop. This update ensures users can scale the grid from any origin point, while preserving correct drag, resize, selection and collision behaviors.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update