### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -238,11 +238,11 @@ const Grid: React.FC<GridProps> = ({
         
         // Calculate distance indicators for spacing between aligned items (only when moving slowly)
         const draggingItem = { ...startPos, x: finalPosition.x, y: finalPosition.y, ...currentItemSize }
-        const distanceIndicators = calculateDistanceIndicators(effectiveLayout.filter(item => item.id !== itemId), draggingItem, snapThreshold)
+        const distanceIndicators = calculateDistanceIndicators(effectiveLayout.filter(item => item.id !== itemId), draggingItem)
         
         // Find relevant snap lines based on alignment (not proximity)
-        const relevantSnapLines = findRelevantSnapLines(allSnapLines, draggingItem, snapThreshold)
-        const extendedSnapLines = extendSnapLinesForItem(relevantSnapLines, draggingItem, width, height)
+        const relevantSnapLines = findRelevantSnapLines(allSnapLines, draggingItem)
+        const extendedSnapLines = extendSnapLinesForItem(relevantSnapLines, draggingItem)
         
         // Combine with distance indicators for display
         const allDisplayLines = [...extendedSnapLines, ...distanceIndicators]
@@ -671,11 +671,11 @@ const Grid: React.FC<GridProps> = ({
           
           // Calculate distance indicators during transformer resize
           const resizingItem = { id: itemId, x: snappedRect.x, y: snappedRect.y, ...currentItemSize }
-          const distanceIndicators = calculateDistanceIndicators(effectiveLayout.filter(item => item.id !== itemId), resizingItem, snapThreshold)
+          const distanceIndicators = calculateDistanceIndicators(effectiveLayout.filter(item => item.id !== itemId), resizingItem)
           
           // Find relevant snap lines for display
-          const relevantSnapLines = findRelevantSnapLines(allSnapLines, resizingItem, snapThreshold)
-          const extendedSnapLines = extendSnapLinesForItem(relevantSnapLines, resizingItem, width, height)
+          const relevantSnapLines = findRelevantSnapLines(allSnapLines, resizingItem)
+          const extendedSnapLines = extendSnapLinesForItem(relevantSnapLines, resizingItem)
           
           // Combine with distance indicators for display
           const allDisplayLines = [...extendedSnapLines, ...distanceIndicators]

--- a/src/utils/snap-lines-utils.ts
+++ b/src/utils/snap-lines-utils.ts
@@ -6,15 +6,15 @@ import { GridItem, SnapLine, SnapBehaviorConfig } from '../types'
 export function calculateGridSnapLines(
   width: number,
   height: number,
-  gridUnitSize: number | [number, number],
+  _gridUnitSize: number | [number, number],
   snapBehavior: SnapBehaviorConfig = { gridCenter: false },
   canvasX = 0,
   canvasY = 0
 ): SnapLine[] {
   const snapLines: SnapLine[] = []
   
-  // Handle both single number and array format
-  const [gridX, gridY] = Array.isArray(gridUnitSize) ? gridUnitSize : [gridUnitSize, gridUnitSize]
+  // Handle both single number and array format (for future grid line implementation)
+  // const [gridX, gridY] = Array.isArray(gridUnitSize) ? gridUnitSize : [gridUnitSize, gridUnitSize]
   
   let lineId = 0
   
@@ -52,8 +52,7 @@ export function calculateGridSnapLines(
  */
 export function calculateDistanceIndicators(
   items: GridItem[],
-  draggingItem: GridItem,
-  snapThreshold = 5
+  draggingItem: GridItem
 ): SnapLine[] {
   const snapLines: SnapLine[] = []
   let lineId = 0
@@ -254,8 +253,7 @@ export function calculateItemSnapLines(
  */
 export function findRelevantSnapLines(
   snapLines: SnapLine[],
-  draggingItem: GridItem,
-  snapThreshold = 5
+  draggingItem: GridItem
 ): SnapLine[] {
   const relevant: SnapLine[] = []
   
@@ -308,9 +306,7 @@ export function findRelevantSnapLines(
  */
 export function extendSnapLinesForItem(
   snapLines: SnapLine[],
-  draggingItem: GridItem,
-  canvasWidth: number,
-  canvasHeight: number
+  draggingItem: GridItem
 ): SnapLine[] {
   return snapLines.map(line => {
     if (line.type === 'vertical') {
@@ -583,13 +579,15 @@ export function applySnapToPosition(
   
   // Apply snapping
   if (closestVerticalSnap) {
-    x = closestVerticalSnap.position
-    snappedLines.push(closestVerticalSnap.line)
+    const { position, line } = closestVerticalSnap
+    x = position
+    snappedLines.push(line)
   }
   
   if (closestHorizontalSnap) {
-    y = closestHorizontalSnap.position
-    snappedLines.push(closestHorizontalSnap.line)
+    const { position, line } = closestHorizontalSnap
+    y = position
+    snappedLines.push(line)
   }
   
   return { x, y, snappedLines }


### PR DESCRIPTION
## Summary
- Fix unused variable TypeScript errors in snap-lines-utils.ts
- Resolve type inference issues with snap line variables
- Ensure clean build with no TypeScript errors

## Technical Details
- Prefixed unused `gridUnitSize` parameter with underscore to indicate intentional non-use
- Removed unused `snapThreshold`, `canvasWidth`, `canvasHeight` parameters from utility functions
- Fixed TypeScript control flow analysis issues with snap line variables using destructuring
- Updated function calls in layout.tsx to match new signatures

## Changes
- Updated function signatures to remove unused parameters
- Fixed TypeScript errors preventing successful build
- Maintained functionality while cleaning up unused code